### PR TITLE
Fix steamGuard skipping

### DIFF
--- a/src/controller/helpers/logger.js
+++ b/src/controller/helpers/logger.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 16.10.2022 13:17:43
+ * Last Modified: 31.10.2022 09:13:16
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/HerrEurobeat>
@@ -51,7 +51,7 @@ module.exports.logger = (type, str, nodate, remove, animation, printNow) => { //
     // Push string to readyafterlogs if bot is still starting and logger calls meets these criteria
     if (!nodate && !remove && !printNow && !readyafter && type.toLowerCase() != "debug" && !str.toLowerCase().includes("error")) { // Startup messages should have nodate enabled -> filter messages with date when bot is not started
         controller.readyafterlogs.push([ type, str, nodate, remove, animation ]);
-        outputlogger("debug", `logger(): Pushing ${str}${outputlogger.colors.reset} to readyafterlogs array`);
+        outputlogger("debug", `logger(): Pushing "${str}${outputlogger.colors.reset}" to readyafterlogs array`);
     } else {
         outputlogger(type, str, nodate, remove, animation);
     }

--- a/src/controller/login.js
+++ b/src/controller/login.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 16.10.2022 13:16:40
+ * Last Modified: 31.10.2022 11:32:41
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/HerrEurobeat>
@@ -92,7 +92,10 @@ module.exports.startlogin = (logininfo) => {
                 if (module.exports.accisloggedin == true && i == Object.keys(controller.botobject).length + this.skippednow.length || module.exports.accisloggedin == true && this.skippednow.includes(i - 1)) { // I is being counted from 0, length from 1 -> checks if last iteration is as long as botobject
                     clearInterval(startnextinterval); // Stop checking
 
-                    // if this iteration exists in the skippedaccounts array, automatically skip acc again
+                    // Start ready check on last iteration
+                    if (Object.keys(logininfo).length == i + 1) require("./ready.js").readyCheck(logininfo);
+
+                    // If this iteration exists in the skippedaccounts array, automatically skip acc again
                     if (controller.skippedaccounts.includes(i)) {
                         logger("info", `[skippedaccounts] Automatically skipped ${k}!`, false, true);
                         this.skippednow.push(i);
@@ -129,8 +132,4 @@ module.exports.startlogin = (logininfo) => {
 
         }, (advancedconfig.loginDelay * (i - this.skippednow.length)) * Number(i > 0)); // Wait loginDelay ms before checking if the next account is ready to be logged in if not first iteration. This should reduce load and ram usage as less intervals run at the same time (this gets more interesting when lots of accs are used)
     });
-
-
-    // Start ready check
-    require("./ready.js").readyCheck(logininfo);
 };

--- a/src/controller/ready.js
+++ b/src/controller/ready.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 01.11.2022 11:28:18
+ * Last Modified: 01.11.2022 11:54:08
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/HerrEurobeat>
@@ -135,7 +135,7 @@ module.exports.readyCheck = (logininfo) => {
             let tempArr = [];
 
             Object.keys(botobject).forEach((e, i) => {
-                tempArr.push(new SteamID(String(controller.botobject[i].steamID)).getSteamID64());
+                tempArr.push(new SteamID(String(Object.values(botobject)[i].steamID)).getSteamID64()); // Use Object.values(obj)[index] to check by index, not by botindex to accomodate for skipped accounts
 
                 // Check if this bot account is listed as an owner id and display warning
                 if (cache.ownerid.includes(tempArr[i])) logger("warn", `You provided an ownerid in the config that points to a bot account used by this bot! This is not allowed.\n       Please change id ${tempArr[i]} to point to your personal steam account!`, true);

--- a/src/controller/ready.js
+++ b/src/controller/ready.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 16.10.2022 17:13:20
+ * Last Modified: 01.11.2022 11:28:18
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/HerrEurobeat>
@@ -37,12 +37,12 @@ module.exports.readyCheck = (logininfo) => {
 
 
     var readyinterval = setInterval(async () => { // Run ready check every x ms
-        let allAccountsInStorage = Object.keys(communityobject).length + login.skippednow.length == Object.keys(logininfo).length;       // Make sure all accounts were processed and are either logged in or were skipped
-        let lastAccPopulated     = botobject[Object.keys(logininfo).length - 1] && botobject[Object.keys(logininfo).length - 1].steamID; // Make sure bot can only start when steamID is populated which sometimes takes a bit longer, causing issues below (see issue #135 for example)
+        let allAccountsInStorage = Object.keys(communityobject).length + login.skippednow.length == Object.keys(logininfo).length; // Make sure all accounts were processed and are either logged in or were skipped
+        let lastAccIndex         = Object.keys(logininfo).length - login.skippednow.length - 1;                                    // Calculate index of last account
+        let lastAccPopulated     = Object.values(botobject)[lastAccIndex] && Object.values(botobject)[lastAccIndex].steamID;       // Make sure bot can only start when steamID is populated which sometimes takes a bit longer, causing issues below (see issue #135 for example)
 
         if (allAccountsInStorage && login.accisloggedin == true && lastAccPopulated) {
             clearInterval(readyinterval); // Stop checking if startup is done
-
 
             // Load plugins
             var plugins = await require("./helpers/loadPlugins.js").loadPlugins();

--- a/src/sessions/sessionHandler.js
+++ b/src/sessions/sessionHandler.js
@@ -4,7 +4,7 @@
  * Created Date: 09.10.2022 12:47:27
  * Author: 3urobeat
  *
- * Last Modified: 01.11.2022 13:38:48
+ * Last Modified: 01.11.2022 14:09:05
  * Modified By: 3urobeat
  *
  * Copyright (c) 2022 3urobeat <https://github.com/HerrEurobeat>
@@ -209,7 +209,10 @@ sessionHandler.prototype._attemptCredentialsLogin = function() {
 
             parent.session.startWithCredentials(parent.logOnOptions)
                 .then((res) => {
-                    if (res.actionRequired) logger("warn", "You shouldn't see this message. steam-session still wants a code but we supplied one?", false, false, null, true); // This should be impossible because we supplied a 2fa code
+                    if (res.actionRequired) {
+                        logger("warn", "You shouldn't see this message. steam-session still wants a code but we supplied one? Skipping account to not soft-lock the bot...", false, false, null, true); // This should be impossible because we supplied a 2fa code}
+                        parent._resolvePromise(null);
+                    }
                 })
                 .catch((err) => {
                     if (err) parent._handleCredentialsLoginError(err); // Let handleCredentialsLoginError helper handle a login error

--- a/src/sessions/sessionHandler.js
+++ b/src/sessions/sessionHandler.js
@@ -4,7 +4,7 @@
  * Created Date: 09.10.2022 12:47:27
  * Author: 3urobeat
  *
- * Last Modified: 15.10.2022 14:02:22
+ * Last Modified: 31.10.2022 09:56:13
  * Modified By: 3urobeat
  *
  * Copyright (c) 2022 3urobeat <https://github.com/HerrEurobeat>
@@ -107,7 +107,7 @@ sessionHandler.prototype._resolvePromise = function(token) {
             controller.skippedaccounts.push(this.loginindex);
             loginfile.skippednow.push(this.loginindex);
 
-            this.session.cancelLoginAttempt(); // Cancel this login attempt just to be sure
+            // Don't call cancelLoginAttempt() as this would result in an error because we aren't polling yet (https://github.com/DoctorMcKay/node-steam-session#polling)
         }
     } else {
         // Save most recent valid token to tokens.db

--- a/src/sessions/sessionHandler.js
+++ b/src/sessions/sessionHandler.js
@@ -4,7 +4,7 @@
  * Created Date: 09.10.2022 12:47:27
  * Author: 3urobeat
  *
- * Last Modified: 31.10.2022 09:56:13
+ * Last Modified: 01.11.2022 13:38:48
  * Modified By: 3urobeat
  *
  * Copyright (c) 2022 3urobeat <https://github.com/HerrEurobeat>
@@ -198,7 +198,7 @@ sessionHandler.prototype._attemptCredentialsLogin = function() {
 
         // Get code input, but supply code to new login system instead of the old one
         get2FAUserInput((code) => {
-            logger("info", "You will receive a second Steam Guard E-Mail from Steam for this account which you can ignore.", false, false, null, true); // https://github.com/DoctorMcKay/node-steam-session/issues/2
+            logger("info", "If this account uses E-Mail Steam Guard then you will receive a second E-Mail from Steam for this account which you can ignore.", false, false, null, true); // https://github.com/DoctorMcKay/node-steam-session/issues/2
 
             parent.session = new SteamSession.LoginSession(SteamSession.EAuthTokenPlatformType.SteamClient);
 
@@ -209,7 +209,7 @@ sessionHandler.prototype._attemptCredentialsLogin = function() {
 
             parent.session.startWithCredentials(parent.logOnOptions)
                 .then((res) => {
-                    if (res.actionRequired) logger("warn", "You shouldn't see this message. steam-session still wants a code but we supplied one?"); // This should be impossible because we supplied a 2fa code
+                    if (res.actionRequired) logger("warn", "You shouldn't see this message. steam-session still wants a code but we supplied one?", false, false, null, true); // This should be impossible because we supplied a 2fa code
                 })
                 .catch((err) => {
                     if (err) parent._handleCredentialsLoginError(err); // Let handleCredentialsLoginError helper handle a login error


### PR DESCRIPTION
This PR fixes a few issues around steamGuard skipping. This includes the ready check not working, the ready cache refresh throwing an error and `cancelLoginAttempt()` throwing an error because polling had not started yet when an account was skipped.