### PR TITLE
Update steam-session dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "https": "^1.0.0",
                 "output-logger": "^2.2.3",
                 "request": "^2.88.2",
-                "steam-session": "^0.0.3-alpha",
+                "steam-session": "^0.0.4-alpha",
                 "steam-user": "^4.25.0",
                 "steamcommunity": "^3.44.3",
                 "steamid": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "https": "^1.0.0",
         "output-logger": "^2.2.3",
         "request": "^2.88.2",
-        "steam-session": "^0.0.3-alpha",
+        "steam-session": "^0.0.4-alpha",
         "steam-user": "^4.25.0",
         "steamcommunity": "^3.44.3",
         "steamid": "^2.0.0",


### PR DESCRIPTION
Fixes #148

It turns out that the old version of the steam session gives an error when logging into the account, updating it seems to fix this problem